### PR TITLE
Update MOOSE API usage, disable XDG tests/tools, and fix XDG build flags for Cardinal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,5 +46,5 @@
 	url = https://github.com/OTU-Centre-for-SMRs/nuclear_data.git
 [submodule "contrib/xdg"]
 	path = contrib/xdg
-	url = https://github.com/ssgudala-bwxt/xdg.git
+	url = https://github.com/pshriwise/xdg.git
 	branch = quad-hex-support

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,5 +46,5 @@
 	url = https://github.com/OTU-Centre-for-SMRs/nuclear_data.git
 [submodule "contrib/xdg"]
 	path = contrib/xdg
-	url = https://github.com/pshriwise/xdg.git
+	url = https://github.com/ssgudala-bwxt/xdg.git
 	branch = quad-hex-support

--- a/config/add_flags.mk
+++ b/config/add_flags.mk
@@ -9,7 +9,10 @@ ifeq ($(ENABLE_OPENMC), yes)
 endif
 
 ifeq ($(ENABLE_XDG), yes)
-  libmesh_CXXFLAGS    += -DENABLE_XDG -DXDG_EMBREE4 -DXDG_ENABLE_LIBMESH -DXDG_ENABLE_MOAB
+	libmesh_CXXFLAGS    += -DENABLE_XDG -DXDG_EMBREE4 -DXDG_ENABLE_LIBMESH
+	ifeq ($(ENABLE_DAGMC), yes)
+	  libmesh_CXXFLAGS  += -DXDG_ENABLE_MOAB
+	endif
 
 	# this flag is used in OpenMC
 	libmesh_CXXFLAGS    += -DOPENMC_XDG_ENABLED

--- a/config/xdg.mk
+++ b/config/xdg.mk
@@ -16,8 +16,8 @@ $(XDG_BUILDDIR)/Makefile: build_moab build_embree | $(XDG_DIR)/CMakeLists.txt
 	-DXDG_ENABLE_LIBMESH=ON \
 	-DXDG_LINK_MPI=ON \
 	-DXDG_ENABLE_EMBREE=ON \
-	-DXDG_BUILD_TESTS=ON \
-	-DXDG_BUILD_TOOLS=ON \
+	-DXDG_BUILD_TESTS=OFF \
+	-DXDG_BUILD_TOOLS=OFF \
 	$(XDG_DIR)
 
 build_xdg: | $(XDG_BUILDDIR)/Makefile

--- a/src/auxkernels/HeatTransferCoefficientAux.C
+++ b/src/auxkernels/HeatTransferCoefficientAux.C
@@ -37,9 +37,9 @@ HeatTransferCoefficientAux::validParams()
 
 HeatTransferCoefficientAux::HeatTransferCoefficientAux(const InputParameters & parameters)
   : AuxKernel(parameters),
-    _heat_flux(getUserObjectBase("heat_flux")),
-    _wall_T(getUserObjectBase("wall_T")),
-    _bulk_T(getUserObjectBase("bulk_T"))
+    _heat_flux(getUserObject<UserObject>("heat_flux")),
+    _wall_T(getUserObject<UserObject>("wall_T")),
+    _bulk_T(getUserObject<UserObject>("bulk_T"))
 {
 }
 


### PR DESCRIPTION
Some changes I needed to make to build Cardinal w/ XDG.

Specifically:

1. Changed three constructor initializer calls in src/auxkernels/HeatTransferCoefficientAux.C from getUserObjectBase("...") to getUserObject<UserObject>("...")
- A MOOSE API change modified this method to return const UserObjectBase& instead of const UserObject&. This was already fixed in the main branch of Cardinal but just needed to update it here.

2. Set XDG_BUILD_TESTS=OFF and XDG_BUILD_TOOLS=OFF in config/xdg.mk
- XDG test and tool executables link against xdg::xdg, but embree is linked PRIVATE to xdg so its headers don't propagate to test targets. Building tests caused "embree4/rtcore.h: No such file or directory". Cardinal doesn't run XDG's unit tests or use the CLI tools *currently* so these can be disabled.

3. Put -DXDG_ENABLE_MOAB in a conditional ENABLE_DAGMC=yes in config/add_flags.mk
- When -DXDG_ENABLE_MOAB was unconditionally present, XDG compiled with MOAB support enabled and included moab/Core.hpp — but MOAB is only built when ENABLE_DAGMC=yes. Without DAGMC, that header doesn't exist, causing a fatal compile error. (I was compiling with ENABLE_DAGMC=false, so maybe just a user issue if I am meant to build with it on with XDG).

4. (Not a cardinal edit but included for completeness). FMT requirements (from XDG) were breaking the build so set FMT_INSTALL=OFF in CMakeLists.txt and removed find_dependency(fmt) from cmake/XDGConfig.cmake.in. 
- OpenMC was importing a stale fmt from XDG causing build errors, so removed the reference to the XDG one. This allowed OpenMC to build its own correct version.